### PR TITLE
Fix Editor.js link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # InlineCode Tool
 
-Inline Tool for marking code-fragments for the [Editor.js](https://ifmo.su/editor).
+Inline Tool for marking code-fragments for the [Editor.js](https://editorjs.io/).
 
 ![](assets/example.gif)
 


### PR DESCRIPTION
Updated Editor.js link in README. Previous link is broken and redirect to another website